### PR TITLE
Fixed compilation on non-debug configurations

### DIFF
--- a/inisg.h
+++ b/inisg.h
@@ -91,6 +91,8 @@ typedef umax ptr_t;
 #		define INISG_DB_realloc(ptr, size) INISG_DMEM(realloc)(ptr, size, __FILE__, __LINE__)
 #		undef DEBUG
 #		define DEBUG 0
+#	else
+#		define ifdebug1(code)
 #	endif /* Debug level 1 */
 #else
 #	define ifdebug1(code)

--- a/inisg.h
+++ b/inisg.h
@@ -91,9 +91,9 @@ typedef umax ptr_t;
 #		define INISG_DB_realloc(ptr, size) INISG_DMEM(realloc)(ptr, size, __FILE__, __LINE__)
 #		undef DEBUG
 #		define DEBUG 0
-#	else
-#		define ifdebug1(code)
 #	endif /* Debug level 1 */
+#else
+#	define ifdebug1(code)
 #endif
 
 


### PR DESCRIPTION
# Issue
Das Projekt konnte nicht ohne DEBUG-Option compiliert werden.

# Grund 
Das Makro `ifdebug1()` wurde ohne debug-build nicht definiert, was zu Fehlern geführt hat.

# Lösung
Die #ifdef-Struktur an der Stelle wurde geändert, sodass `ifdebug1()` immer definiert wird.